### PR TITLE
Fix typo in network name.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,4 +67,4 @@ services:
       - --service-url=http://coordinator-service:8000/graphql
 networks:
   default:
-    name: cooridnator-service
+    name: coordinator-service


### PR DESCRIPTION
Fix for a small typo in the Docker compose network name.